### PR TITLE
Analyze IPTV source addresses

### DIFF
--- a/jp.csv
+++ b/jp.csv
@@ -1,0 +1,72 @@
+name,group,tvg_id,tvg_logo,protocol,domain,path,url
+We need donations to maintain the server! | サーバー維持のため寄付募集中！,,,,https,mt01.utako.moe,/test/intro.mp4/index.m3u8,https://mt01.utako.moe/test/intro.mp4/index.m3u8
+Donate/寄付: https://ko-fi.com/dinhluong,,,,https,mt01.utako.moe,/test/intro.mp4/index.m3u8,https://mt01.utako.moe/test/intro.mp4/index.m3u8
+Please refrain from re-sharing those URLs! Read github for details.,,,,https,mt01.utako.moe,/test/intro.mp4/index.m3u8,https://mt01.utako.moe/test/intro.mp4/index.m3u8
+「utako.moe」リンクURLの他所への転載お断り!!詳細はgithubのREADME,,,,https,mt01.utako.moe,/test/intro.mp4/index.m3u8,https://mt01.utako.moe/test/intro.mp4/index.m3u8
+NHK G,,,,https,mt01.utako.moe,/NHK_G/index.m3u8,https://mt01.utako.moe/NHK_G/index.m3u8
+NHK E,,,,https,mt01.utako.moe,/NHK_E/index.m3u8,https://mt01.utako.moe/NHK_E/index.m3u8
+NTV,,,,https,mt01.utako.moe,/Nippon_TV/index.m3u8,https://mt01.utako.moe/Nippon_TV/index.m3u8
+TBS,,,,https,mt01.utako.moe,/TBS/index.m3u8,https://mt01.utako.moe/TBS/index.m3u8
+Fuji TV,,,,https,mt01.utako.moe,/Fuji_TV/index.m3u8,https://mt01.utako.moe/Fuji_TV/index.m3u8
+TV Asahi,,,,https,mt01.utako.moe,/TV_Asahi/index.m3u8,https://mt01.utako.moe/TV_Asahi/index.m3u8
+TV Tokyo,,,,https,mt01.utako.moe,/TV_Tokyo/index.m3u8,https://mt01.utako.moe/TV_Tokyo/index.m3u8
+TOKYO MX1,,,,https,mt01.utako.moe,/Tokyo_MX1/index.m3u8,https://mt01.utako.moe/Tokyo_MX1/index.m3u8
+TOKYO MX2,,,,https,mt01.utako.moe,/Tokyo_MX2/index.m3u8,https://mt01.utako.moe/Tokyo_MX2/index.m3u8
+MBS,,,,https,mt01.utako.moe,/mbs/index.m3u8,https://mt01.utako.moe/mbs/index.m3u8
+ABC,,,,https,mt01.utako.moe,/abc/index.m3u8,https://mt01.utako.moe/abc/index.m3u8
+TV Osaka,,,,https,mt01.utako.moe,/tvo/index.m3u8,https://mt01.utako.moe/tvo/index.m3u8
+Kansai TV,,,,https,mt01.utako.moe,/kansaitv/index.m3u8,https://mt01.utako.moe/kansaitv/index.m3u8
+ytv,,,,https,mt01.utako.moe,/ytv/index.m3u8,https://mt01.utako.moe/ytv/index.m3u8
+KBS,,,,https,mt01.utako.moe,/kbs/index.m3u8,https://mt01.utako.moe/kbs/index.m3u8
+SUN,,,,https,mt01.utako.moe,/suntv/index.m3u8,https://mt01.utako.moe/suntv/index.m3u8
+NHK BS,,,,https,mt01.utako.moe,/NHK_BS/index.m3u8,https://mt01.utako.moe/NHK_BS/index.m3u8
+BS NTV,,,,https,mt01.utako.moe,/bsntv/index.m3u8,https://mt01.utako.moe/bsntv/index.m3u8
+BS Asahi,,,,https,mt01.utako.moe,/bsasahi/index.m3u8,https://mt01.utako.moe/bsasahi/index.m3u8
+BS TBS,,,,https,mt01.utako.moe,/bstbs/index.m3u8,https://mt01.utako.moe/bstbs/index.m3u8
+BS TV Tokyo,,,,https,mt01.utako.moe,/bstvtokyo/index.m3u8,https://mt01.utako.moe/bstvtokyo/index.m3u8
+BS Fuji,,,,https,mt01.utako.moe,/bsfuji/index.m3u8,https://mt01.utako.moe/bsfuji/index.m3u8
+BS10,,,,https,mt01.utako.moe,/bs10/index.m3u8,https://mt01.utako.moe/bs10/index.m3u8
+BS11,,,,https,mt01.utako.moe,/BS11/index.m3u8,https://mt01.utako.moe/BS11/index.m3u8
+BS12,,,,https,mt01.utako.moe,/bs12/index.m3u8,https://mt01.utako.moe/bs12/index.m3u8
+NHK BS4K,,,,https,mt01.utako.moe,/bsp4k/index.m3u8,https://mt01.utako.moe/bsp4k/index.m3u8
+BS TV Tokyo 4K (test),,,,https,mt01.utako.moe,/bstx4k/index.m3u8,https://mt01.utako.moe/bstx4k/index.m3u8
+WOWOW Prime,,,,https,mt01.utako.moe,/wprime/index.m3u8,https://mt01.utako.moe/wprime/index.m3u8
+WOWOW Cinema,,,,https,mt01.utako.moe,/wcinema/index.m3u8,https://mt01.utako.moe/wcinema/index.m3u8
+WOWOW Live,,,,https,mt01.utako.moe,/wlive/index.m3u8,https://mt01.utako.moe/wlive/index.m3u8
+BS 10 Star Channel,,,,https,mt01.utako.moe,/bs10_star/index.m3u8,https://mt01.utako.moe/bs10_star/index.m3u8
+JSport 1,,,,https,mt01.utako.moe,/js1/index.m3u8,https://mt01.utako.moe/js1/index.m3u8
+JSport 2,,,,https,mt01.utako.moe,/js2/index.m3u8,https://mt01.utako.moe/js2/index.m3u8
+JSport 3,,,,https,mt01.utako.moe,/js3/index.m3u8,https://mt01.utako.moe/js3/index.m3u8
+JSport 4,,,,https,mt01.utako.moe,/js4/index.m3u8,https://mt01.utako.moe/js4/index.m3u8
+Green Channel,,,,https,mt01.utako.moe,/green/index.m3u8,https://mt01.utako.moe/green/index.m3u8
+Animax,,,,https,mt02.utako.moe,/Animax/index.m3u8,https://mt02.utako.moe/Animax/index.m3u8
+Nihon Eiga Senmon,,,,https,mt02.utako.moe,/nihoneiga/index.m3u8,https://mt02.utako.moe/nihoneiga/index.m3u8
+Sky A,,,,https,mt02.utako.moe,/skya/index.m3u8,https://mt02.utako.moe/skya/index.m3u8
+Gaora Sports,,,,https,mt01.utako.moe,/gaora/index.m3u8,https://mt01.utako.moe/gaora/index.m3u8
+AT-X,,,,https,mt01.utako.moe,/AT-X/index.m3u8,https://mt01.utako.moe/AT-X/index.m3u8
+Space Shower TV,,,,https,mt02.utako.moe,/spaceshower/index.m3u8,https://mt02.utako.moe/spaceshower/index.m3u8
+MTV,,,,https,mt02.utako.moe,/mtv/index.m3u8,https://mt02.utako.moe/mtv/index.m3u8
+Kayo Pops,,,,https,mt02.utako.moe,/kayopops/index.m3u8,https://mt02.utako.moe/kayopops/index.m3u8
+Disney Channel,,,,https,mt02.utako.moe,/disneychan/index.m3u8,https://mt02.utako.moe/disneychan/index.m3u8
+Cartoon Network Japan,,,,https,mt02.utako.moe,/cartoon_network/index.m3u8,https://mt02.utako.moe/cartoon_network/index.m3u8
+Nittele G+,,,,https,mt02.utako.moe,/ntvgplus/index.m3u8,https://mt02.utako.moe/ntvgplus/index.m3u8
+Family Gekijyo,,,,https,mt02.utako.moe,/familygeki/index.m3u8,https://mt02.utako.moe/familygeki/index.m3u8
+Mondo TV,,,,https,mt02.utako.moe,/mondo/index.m3u8,https://mt02.utako.moe/mondo/index.m3u8
+TBS Channel 1,,,,https,mt02.utako.moe,/tbsch1/index.m3u8,https://mt02.utako.moe/tbsch1/index.m3u8
+TBS Channel 2,,,,https,mt02.utako.moe,/tbsch2/index.m3u8,https://mt02.utako.moe/tbsch2/index.m3u8
+TV Asahi Channel 1,,,,https,mt02.utako.moe,/ex_ch1/index.m3u8,https://mt02.utako.moe/ex_ch1/index.m3u8
+TV Asahi Channel 2,,,,https,mt02.utako.moe,/ex_ch2/index.m3u8,https://mt02.utako.moe/ex_ch2/index.m3u8
+Fuji TV ONE,,,,https,mt02.utako.moe,/fuji_one/index.m3u8,https://mt02.utako.moe/fuji_one/index.m3u8
+Fuji TV TWO,,,,https,mt02.utako.moe,/fuji_two/index.m3u8,https://mt02.utako.moe/fuji_two/index.m3u8
+Fuji TV NEXT,,,,https,mt02.utako.moe,/fuji_next/index.m3u8,https://mt02.utako.moe/fuji_next/index.m3u8
+Neco Channel,,,,https,mt02.utako.moe,/neco/index.m3u8,https://mt02.utako.moe/neco/index.m3u8
+Dlife,,,,https,mt02.utako.moe,/dlife/index.m3u8,https://mt02.utako.moe/dlife/index.m3u8
+Toei Channel,,,,https,mt02.utako.moe,/toei/index.m3u8,https://mt02.utako.moe/toei/index.m3u8
+Fighting TV Samurai,,,,https,mt02.utako.moe,/fighting_tv/index.m3u8,https://mt02.utako.moe/fighting_tv/index.m3u8
+Entermei Tele,,,,https,mt02.utako.moe,/entermei_tele/index.m3u8,https://mt02.utako.moe/entermei_tele/index.m3u8
+Sport Live Plus,,,,https,mt02.utako.moe,/sport_live_plus/index.m3u8,https://mt02.utako.moe/sport_live_plus/index.m3u8
+Home Drama Channel,,,,https,mt02.utako.moe,/homedrama/index.m3u8,https://mt02.utako.moe/homedrama/index.m3u8
+Channel Ginga,,,,https,mt02.utako.moe,/gingach/index.m3u8,https://mt02.utako.moe/gingach/index.m3u8
+Tabi Channel,,,,https,mt02.utako.moe,/tabi/index.m3u8,https://mt02.utako.moe/tabi/index.m3u8
+Pigoo (NSFW),,,,https,mt02.utako.moe,/pigoo/index.m3u8,https://mt02.utako.moe/pigoo/index.m3u8
+V Paradise (NSFW),,,,https,mt02.utako.moe,/v_paradise/index.m3u8,https://mt02.utako.moe/v_paradise/index.m3u8

--- a/jp_clean.csv
+++ b/jp_clean.csv
@@ -1,0 +1,70 @@
+name,group,tvg_id,tvg_logo,protocol,domain,path,url
+We need donations to maintain the server! | サーバー維持のため寄付募集中！,,,,https,mt01.utako.moe,/test/intro.mp4/index.m3u8,https://mt01.utako.moe/test/intro.mp4/index.m3u8
+Donate/寄付: https://ko-fi.com/dinhluong,,,,https,mt01.utako.moe,/test/intro.mp4/index.m3u8,https://mt01.utako.moe/test/intro.mp4/index.m3u8
+Please refrain from re-sharing those URLs! Read github for details.,,,,https,mt01.utako.moe,/test/intro.mp4/index.m3u8,https://mt01.utako.moe/test/intro.mp4/index.m3u8
+「utako.moe」リンクURLの他所への転載お断り!!詳細はgithubのREADME,,,,https,mt01.utako.moe,/test/intro.mp4/index.m3u8,https://mt01.utako.moe/test/intro.mp4/index.m3u8
+NHK G,,,,https,mt01.utako.moe,/NHK_G/index.m3u8,https://mt01.utako.moe/NHK_G/index.m3u8
+NHK E,,,,https,mt01.utako.moe,/NHK_E/index.m3u8,https://mt01.utako.moe/NHK_E/index.m3u8
+NTV,,,,https,mt01.utako.moe,/Nippon_TV/index.m3u8,https://mt01.utako.moe/Nippon_TV/index.m3u8
+TBS,,,,https,mt01.utako.moe,/TBS/index.m3u8,https://mt01.utako.moe/TBS/index.m3u8
+Fuji TV,,,,https,mt01.utako.moe,/Fuji_TV/index.m3u8,https://mt01.utako.moe/Fuji_TV/index.m3u8
+TV Asahi,,,,https,mt01.utako.moe,/TV_Asahi/index.m3u8,https://mt01.utako.moe/TV_Asahi/index.m3u8
+TV Tokyo,,,,https,mt01.utako.moe,/TV_Tokyo/index.m3u8,https://mt01.utako.moe/TV_Tokyo/index.m3u8
+TOKYO MX1,,,,https,mt01.utako.moe,/Tokyo_MX1/index.m3u8,https://mt01.utako.moe/Tokyo_MX1/index.m3u8
+TOKYO MX2,,,,https,mt01.utako.moe,/Tokyo_MX2/index.m3u8,https://mt01.utako.moe/Tokyo_MX2/index.m3u8
+MBS,,,,https,mt01.utako.moe,/mbs/index.m3u8,https://mt01.utako.moe/mbs/index.m3u8
+ABC,,,,https,mt01.utako.moe,/abc/index.m3u8,https://mt01.utako.moe/abc/index.m3u8
+TV Osaka,,,,https,mt01.utako.moe,/tvo/index.m3u8,https://mt01.utako.moe/tvo/index.m3u8
+Kansai TV,,,,https,mt01.utako.moe,/kansaitv/index.m3u8,https://mt01.utako.moe/kansaitv/index.m3u8
+ytv,,,,https,mt01.utako.moe,/ytv/index.m3u8,https://mt01.utako.moe/ytv/index.m3u8
+KBS,,,,https,mt01.utako.moe,/kbs/index.m3u8,https://mt01.utako.moe/kbs/index.m3u8
+SUN,,,,https,mt01.utako.moe,/suntv/index.m3u8,https://mt01.utako.moe/suntv/index.m3u8
+NHK BS,,,,https,mt01.utako.moe,/NHK_BS/index.m3u8,https://mt01.utako.moe/NHK_BS/index.m3u8
+BS NTV,,,,https,mt01.utako.moe,/bsntv/index.m3u8,https://mt01.utako.moe/bsntv/index.m3u8
+BS Asahi,,,,https,mt01.utako.moe,/bsasahi/index.m3u8,https://mt01.utako.moe/bsasahi/index.m3u8
+BS TBS,,,,https,mt01.utako.moe,/bstbs/index.m3u8,https://mt01.utako.moe/bstbs/index.m3u8
+BS TV Tokyo,,,,https,mt01.utako.moe,/bstvtokyo/index.m3u8,https://mt01.utako.moe/bstvtokyo/index.m3u8
+BS Fuji,,,,https,mt01.utako.moe,/bsfuji/index.m3u8,https://mt01.utako.moe/bsfuji/index.m3u8
+BS10,,,,https,mt01.utako.moe,/bs10/index.m3u8,https://mt01.utako.moe/bs10/index.m3u8
+BS11,,,,https,mt01.utako.moe,/BS11/index.m3u8,https://mt01.utako.moe/BS11/index.m3u8
+BS12,,,,https,mt01.utako.moe,/bs12/index.m3u8,https://mt01.utako.moe/bs12/index.m3u8
+NHK BS4K,,,,https,mt01.utako.moe,/bsp4k/index.m3u8,https://mt01.utako.moe/bsp4k/index.m3u8
+BS TV Tokyo 4K (test),,,,https,mt01.utako.moe,/bstx4k/index.m3u8,https://mt01.utako.moe/bstx4k/index.m3u8
+WOWOW Prime,,,,https,mt01.utako.moe,/wprime/index.m3u8,https://mt01.utako.moe/wprime/index.m3u8
+WOWOW Cinema,,,,https,mt01.utako.moe,/wcinema/index.m3u8,https://mt01.utako.moe/wcinema/index.m3u8
+WOWOW Live,,,,https,mt01.utako.moe,/wlive/index.m3u8,https://mt01.utako.moe/wlive/index.m3u8
+BS 10 Star Channel,,,,https,mt01.utako.moe,/bs10_star/index.m3u8,https://mt01.utako.moe/bs10_star/index.m3u8
+JSport 1,,,,https,mt01.utako.moe,/js1/index.m3u8,https://mt01.utako.moe/js1/index.m3u8
+JSport 2,,,,https,mt01.utako.moe,/js2/index.m3u8,https://mt01.utako.moe/js2/index.m3u8
+JSport 3,,,,https,mt01.utako.moe,/js3/index.m3u8,https://mt01.utako.moe/js3/index.m3u8
+JSport 4,,,,https,mt01.utako.moe,/js4/index.m3u8,https://mt01.utako.moe/js4/index.m3u8
+Green Channel,,,,https,mt01.utako.moe,/green/index.m3u8,https://mt01.utako.moe/green/index.m3u8
+Animax,,,,https,mt02.utako.moe,/Animax/index.m3u8,https://mt02.utako.moe/Animax/index.m3u8
+Nihon Eiga Senmon,,,,https,mt02.utako.moe,/nihoneiga/index.m3u8,https://mt02.utako.moe/nihoneiga/index.m3u8
+Sky A,,,,https,mt02.utako.moe,/skya/index.m3u8,https://mt02.utako.moe/skya/index.m3u8
+Gaora Sports,,,,https,mt01.utako.moe,/gaora/index.m3u8,https://mt01.utako.moe/gaora/index.m3u8
+AT-X,,,,https,mt01.utako.moe,/AT-X/index.m3u8,https://mt01.utako.moe/AT-X/index.m3u8
+Space Shower TV,,,,https,mt02.utako.moe,/spaceshower/index.m3u8,https://mt02.utako.moe/spaceshower/index.m3u8
+MTV,,,,https,mt02.utako.moe,/mtv/index.m3u8,https://mt02.utako.moe/mtv/index.m3u8
+Kayo Pops,,,,https,mt02.utako.moe,/kayopops/index.m3u8,https://mt02.utako.moe/kayopops/index.m3u8
+Disney Channel,,,,https,mt02.utako.moe,/disneychan/index.m3u8,https://mt02.utako.moe/disneychan/index.m3u8
+Cartoon Network Japan,,,,https,mt02.utako.moe,/cartoon_network/index.m3u8,https://mt02.utako.moe/cartoon_network/index.m3u8
+Nittele G+,,,,https,mt02.utako.moe,/ntvgplus/index.m3u8,https://mt02.utako.moe/ntvgplus/index.m3u8
+Family Gekijyo,,,,https,mt02.utako.moe,/familygeki/index.m3u8,https://mt02.utako.moe/familygeki/index.m3u8
+Mondo TV,,,,https,mt02.utako.moe,/mondo/index.m3u8,https://mt02.utako.moe/mondo/index.m3u8
+TBS Channel 1,,,,https,mt02.utako.moe,/tbsch1/index.m3u8,https://mt02.utako.moe/tbsch1/index.m3u8
+TBS Channel 2,,,,https,mt02.utako.moe,/tbsch2/index.m3u8,https://mt02.utako.moe/tbsch2/index.m3u8
+TV Asahi Channel 1,,,,https,mt02.utako.moe,/ex_ch1/index.m3u8,https://mt02.utako.moe/ex_ch1/index.m3u8
+TV Asahi Channel 2,,,,https,mt02.utako.moe,/ex_ch2/index.m3u8,https://mt02.utako.moe/ex_ch2/index.m3u8
+Fuji TV ONE,,,,https,mt02.utako.moe,/fuji_one/index.m3u8,https://mt02.utako.moe/fuji_one/index.m3u8
+Fuji TV TWO,,,,https,mt02.utako.moe,/fuji_two/index.m3u8,https://mt02.utako.moe/fuji_two/index.m3u8
+Fuji TV NEXT,,,,https,mt02.utako.moe,/fuji_next/index.m3u8,https://mt02.utako.moe/fuji_next/index.m3u8
+Neco Channel,,,,https,mt02.utako.moe,/neco/index.m3u8,https://mt02.utako.moe/neco/index.m3u8
+Dlife,,,,https,mt02.utako.moe,/dlife/index.m3u8,https://mt02.utako.moe/dlife/index.m3u8
+Toei Channel,,,,https,mt02.utako.moe,/toei/index.m3u8,https://mt02.utako.moe/toei/index.m3u8
+Fighting TV Samurai,,,,https,mt02.utako.moe,/fighting_tv/index.m3u8,https://mt02.utako.moe/fighting_tv/index.m3u8
+Entermei Tele,,,,https,mt02.utako.moe,/entermei_tele/index.m3u8,https://mt02.utako.moe/entermei_tele/index.m3u8
+Sport Live Plus,,,,https,mt02.utako.moe,/sport_live_plus/index.m3u8,https://mt02.utako.moe/sport_live_plus/index.m3u8
+Home Drama Channel,,,,https,mt02.utako.moe,/homedrama/index.m3u8,https://mt02.utako.moe/homedrama/index.m3u8
+Channel Ginga,,,,https,mt02.utako.moe,/gingach/index.m3u8,https://mt02.utako.moe/gingach/index.m3u8
+Tabi Channel,,,,https,mt02.utako.moe,/tabi/index.m3u8,https://mt02.utako.moe/tabi/index.m3u8

--- a/tools/export_m3u_to_csv.py
+++ b/tools/export_m3u_to_csv.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+import csv
+import os
+import re
+import sys
+from urllib.parse import urlparse
+
+
+EXTINF_PATTERN = re.compile(r"#EXTINF:[^,]*,(.*)")
+ATTR_PATTERN = re.compile(r"(\w+?)=\"(.*?)\"")
+
+
+def parse_m3u(m3u_path: str):
+    channels = []
+    pending_meta = None
+
+    def parse_attrs(line: str) -> dict:
+        attrs = {}
+        for key, value in ATTR_PATTERN.findall(line):
+            attrs[key] = value
+        return attrs
+
+    with open(m3u_path, "r", encoding="utf-8", errors="ignore") as f:
+        for raw_line in f:
+            line = raw_line.strip()
+            if not line:
+                continue
+
+            if line.startswith("#EXTM3U"):
+                # header; could contain url-tvg etc., not used per-row
+                continue
+
+            if line.startswith("#EXTINF"):
+                attrs = parse_attrs(line)
+                match = EXTINF_PATTERN.search(line)
+                name = match.group(1).strip() if match else ""
+                pending_meta = {
+                    "name": name,
+                    "group": attrs.get("group-title", ""),
+                    "tvg_id": attrs.get("tvg-id", ""),
+                    "tvg_logo": attrs.get("tvg-logo", ""),
+                }
+                continue
+
+            if pending_meta and (line.startswith("http://") or line.startswith("https://")):
+                url = line
+                parsed = urlparse(url)
+                record = {
+                    **pending_meta,
+                    "url": url,
+                    "protocol": parsed.scheme,
+                    "domain": parsed.hostname or "",
+                    "path": parsed.path or "",
+                }
+                channels.append(record)
+                pending_meta = None
+                continue
+
+            # Ignore other lines
+
+    return channels
+
+
+def write_csv(channels, csv_path: str):
+    fieldnames = [
+        "name",
+        "group",
+        "tvg_id",
+        "tvg_logo",
+        "protocol",
+        "domain",
+        "path",
+        "url",
+    ]
+    with open(csv_path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in channels:
+            writer.writerow(row)
+
+
+def main():
+    if len(sys.argv) < 3:
+        print("Usage: export_m3u_to_csv.py INPUT.m3u OUTPUT.csv")
+        sys.exit(1)
+    input_path = sys.argv[1]
+    output_path = sys.argv[2]
+    if not os.path.isfile(input_path):
+        print(f"Input not found: {input_path}")
+        sys.exit(2)
+    channels = parse_m3u(input_path)
+    write_csv(channels, output_path)
+    print(f"Wrote {len(channels)} rows to {output_path}")
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
Export IPTV source addresses to CSV files for `jp.m3u` and `jp_clean.m3u` playlists.

The user requested a tabular export of all channels and their URLs after the initial analysis, which this PR fulfills by adding a Python script to parse M3U files and generate CSVs.

---
<a href="https://cursor.com/background-agent?bcId=bc-5257eb7e-b458-420e-948d-f7c344a0ebf5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5257eb7e-b458-420e-948d-f7c344a0ebf5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

